### PR TITLE
Fix for incorrect LC_CTYPE sent from OS X via SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*pyc
+fabfile.py
+*swp

--- a/command-not-found
+++ b/command-not-found
@@ -12,6 +12,7 @@ try:
     import gettext
     import locale
     import sys
+    import os
     from optparse import OptionParser
 
     from CommandNotFound.util import crash_guard
@@ -26,7 +27,16 @@ def enable_i18n():
     if sys.version < '3':
         kwargs["unicode"] = True
     cnf.install(**kwargs)
-    locale.setlocale(locale.LC_ALL, '')
+
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error as exc:
+        #   Fixing the case when remote system sends incorrect LC_CTYPE via SSH
+        if os.environ['LC_CTYPE'] == 'UTF-8':  # Mac OS X
+            #   Set the locale based on LANG environmental variable
+            locale.setlocale(locale.LC_ALL, os.environ['LANG'].split('.'))
+        else:
+            raise exc
 
 
 def fix_sys_argv(encoding=None):

--- a/command-not-found
+++ b/command-not-found
@@ -34,7 +34,7 @@ def enable_i18n():
         #   Fixing the case when remote system sends incorrect LC_CTYPE via SSH
         if os.environ['LC_CTYPE'] == 'UTF-8':  # Mac OS X
             #   Set the locale based on LANG environmental variable
-            locale.setlocale(locale.LC_ALL, os.environ['LANG'].split('.'))
+            locale.setlocale(locale.LC_ALL, os.environ.get('LANG', 'C'))
         else:
             raise exc
 


### PR DESCRIPTION
This fix is maybe somewhat too specific, since it first checks if LC_CTYPE is set to "UTF-8".

I tested this on several systems, and it does solve (kind  of) the problem. Basically, if `locale.setlocale(locale.LC_ALL, '')` fails,  it calls the following instead:

```
locale.setlocale(locale.LC_ALL, ('en_us', 'UTF-8'))
```

'en_us' and 'UTF-8' are derived from LANG environmental variable, which is specific to remote Ubuntu system.
